### PR TITLE
Fix invitation language #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.1] = 2020-08-05
+### Changed
+- Allow the language to be specified in the URL
+
+
 ## [0.1.1] = 2020-08-05
 ### Changed
 - Fixed redirect when declining an invitation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "web version of mindlogger",
   "author": "Anisha Keshavan <anisha@childmind.org>",
   "private": true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,7 @@ export default {
       config
     };
   },
+
   computed: {
     isLoggedIn() {
       return !_.isEmpty(this.user);
@@ -70,6 +71,12 @@ export default {
       return this.$route.query;
     }
   },
+
+  /**
+   * Method to be executed after the VNode was inserted in the DOM.
+   *
+   * @returns {void}
+   */
   mounted() {
     try {
       this.user = JSON.parse(localStorage.getItem("user")) || {};
@@ -77,9 +84,26 @@ export default {
       this.user = {};
     }
   },
+
+  /**
+   * List all the component dependencies.
+   */
   components: {
     Navbar
   },
+
+  /**
+   * This method gets executed when the VNode has been created.
+   *
+   * @returns {void}
+   */
+  created() {
+    this.$store.commit('setCurrentLanguage', this.$route.query.lang || 'en_US');
+  },
+
+  /**
+   * Define here all methods that will be available in the scope of the template.
+   */
   methods: {
     saveUser(u) {
       this.user = u;

--- a/src/lib/language/language.js
+++ b/src/lib/language/language.js
@@ -1,34 +1,46 @@
+// Third-party libraries.
 import Vue from "vue";
 import VueI18n from "vue-i18n";
-import store from "../../store/store";
 import _ from "lodash";
 
+// Local.
+import store from "../../store/store";
+
+// Translations.
 import en_US from "./locales/en_US";
 import fr_FR from "./locales/fr_FR";
 
+
 Vue.use(VueI18n);
 
-// detect browser language
-const browserLanguage = (() => {
+/**
+ * Detects the browser langauge.
+ *
+ * @returns {string} the current browser language.
+ */
+const getBrowserLanguage = () => {
   const language = navigator.language || navigator.userLanguage;
 
-  if (
-    ["fr", "fr-BE", "fr-CA", "fr-CH", "fr-FR", "fr-LU", "fr-MC"].includes(
-      language
-    )
-  ) {
-    return "fr_FR";
+  if (language.startsWith('fr')) {
+    return 'fr_FR';
   }
 
-  return "en_US";
-})();
+  return 'en_US';
+};
 
-// check if a language setting is stored already
-const locale = _.get(store, "state.currentLanguage", browserLanguage);
+// Detect language in the URL.
+const queryString = window.location.hash.split('?').pop();
+const urlParams = new URLSearchParams(queryString);
+const urlLanguage = urlParams.get('lang');
+
 
 // new instance
 export default new VueI18n({
-  locale,
+  locale: (
+    urlLanguage ||
+    _.get(store, 'state.currentLanguage') ||
+    getBrowserLanguage()
+  ),
   lazy: true,
   messages: {
     en_US,


### PR DESCRIPTION
Allows the language to be defined in the URL.

Fixes #87 

**Testing this PR**
1. Open a new tab (note that this step is important)
2. Enter the URL for the web app and add `?lang=fr_FR` at the end
3. Navigate to that URL
4. Pay attention to the result
5. Repeat this process with `?lang=en_US`

**Expected result**
The app should be in the selected language.